### PR TITLE
Allow for custom key and children fields

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -10,8 +10,8 @@ class NodeHeader extends React.Component {
         super(props);
     }
     render(){
-        const {style, animations, decorators, childrenField} = this.props;
-        const terminal = !this.props.node[childrenField];
+        const {style, animations, decorators, childrenGetter} = this.props;
+        const terminal = !childrenGetter(this.props.node);
         const active = this.props.node.active;
         const linkStyle = [style.link, active ? style.activeLink : null];
         return (
@@ -46,7 +46,7 @@ NodeHeader.propTypes = {
     animations: React.PropTypes.object.isRequired,
     node: React.PropTypes.object.isRequired,
     onClick: React.PropTypes.func,
-    childrenField: React.PropTypes.string
+    childrenGetter: React.PropTypes.func.isRequired
 };
 
 export default NodeHeader;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -10,8 +10,8 @@ class NodeHeader extends React.Component {
         super(props);
     }
     render(){
-        const {style, animations, decorators} = this.props;
-        const terminal = !this.props.node.children;
+        const {style, animations, decorators, childrenField} = this.props;
+        const terminal = !this.props.node[childrenField];
         const active = this.props.node.active;
         const linkStyle = [style.link, active ? style.activeLink : null];
         return (
@@ -45,7 +45,8 @@ NodeHeader.propTypes = {
     decorators: React.PropTypes.object.isRequired,
     animations: React.PropTypes.object.isRequired,
     node: React.PropTypes.object.isRequired,
-    onClick: React.PropTypes.func
+    onClick: React.PropTypes.func,
+    childrenField: React.PropTypes.string
 };
 
 export default NodeHeader;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -52,9 +52,10 @@ class TreeNode extends React.Component {
         );
     }
     renderHeader(decorators, animations){
+        const {childrenGetter} = this.props;
         return (
             <NodeHeader
-                childrenField={this.props.childrenField}
+                childrenGetter={childrenGetter}
                 decorators={decorators}
                 animations={animations}
                 style={this.props.style}
@@ -64,14 +65,16 @@ class TreeNode extends React.Component {
         );
     }
     renderChildren(decorators){
-        const {keyField, childrenField} = this.props;
+        const {keyGetter, childrenGetter} = this.props;
         if(this.props.node.loading){ return this.renderLoading(decorators); }
         return (
             <ul style={this.props.style.subtree} ref="subtree">
-                {rutils.children.map(this.props.node[childrenField], (child, index) =>
+                {rutils.children.map(childrenGetter(this.props.node), (child, index) =>
                     <TreeNode
                         {...this._eventBubbles()}
-                        key={keyField?child[keyField]:index}
+                        key={keyGetter(child, index)}
+                        keyGetter={keyGetter}
+                        childrenGetter={childrenGetter}
                         node={child}
                         decorators={this.props.decorators}
                         animations={this.props.animations}
@@ -101,8 +104,8 @@ TreeNode.propTypes = {
     decorators: React.PropTypes.object.isRequired,
     animations: React.PropTypes.object.isRequired,
     onToggle: React.PropTypes.func,
-    keyField: React.PropTypes.string,
-    childrenField: React.PropTypes.string
+    childrenGetter: React.PropTypes.func.isRequired,
+    keyGetter: React.PropTypes.func.isRequired
 };
 
 export default TreeNode;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -54,6 +54,7 @@ class TreeNode extends React.Component {
     renderHeader(decorators, animations){
         return (
             <NodeHeader
+                childrenField={this.props.childrenField}
                 decorators={decorators}
                 animations={animations}
                 style={this.props.style}
@@ -63,13 +64,14 @@ class TreeNode extends React.Component {
         );
     }
     renderChildren(decorators){
+        const {keyField, childrenField} = this.props;
         if(this.props.node.loading){ return this.renderLoading(decorators); }
         return (
             <ul style={this.props.style.subtree} ref="subtree">
-                {rutils.children.map(this.props.node.children, (child, index) =>
+                {rutils.children.map(this.props.node[childrenField], (child, index) =>
                     <TreeNode
                         {...this._eventBubbles()}
-                        key={index}
+                        key={keyField?child[keyField]:index}
                         node={child}
                         decorators={this.props.decorators}
                         animations={this.props.animations}
@@ -98,7 +100,9 @@ TreeNode.propTypes = {
     node: React.PropTypes.object.isRequired,
     decorators: React.PropTypes.object.isRequired,
     animations: React.PropTypes.object.isRequired,
-    onToggle: React.PropTypes.func
+    onToggle: React.PropTypes.func,
+    keyField: React.PropTypes.string,
+    childrenField: React.PropTypes.string
 };
 
 export default TreeNode;

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -12,19 +12,21 @@ class TreeBeard extends React.Component {
         super(props);
     }
     render(){
-        let data = this.props.data;
+        let {data, keyField} = this.props;
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
         if(!Array.isArray(data)){ data = [data]; }
         return (
             <ul style={this.props.style.tree.base} ref="treeBase">
                 {data.map((node, index) =>
                     <TreeNode
-                        key={index}
+                        key={keyField?node[keyField]:index}
                         node={node}
                         onToggle={this.props.onToggle}
                         animations={this.props.animations}
                         decorators={this.props.decorators}
                         style={this.props.style.tree.node}
+                        childrenField={this.props.childrenField}
+                        keyField={keyField}
                     />
                 )}
             </ul>
@@ -40,13 +42,16 @@ TreeBeard.propTypes = {
     ]).isRequired,
     animations: React.PropTypes.object,
     onToggle: React.PropTypes.func,
-    decorators: React.PropTypes.object
+    decorators: React.PropTypes.object,
+    keyField: React.PropTypes.string,
+    childrenField: React.PropTypes.string
 };
 
 TreeBeard.defaultProps = {
     style: defaultTheme,
     animations: defaultAnimations,
-    decorators: defaultDecorators
+    decorators: defaultDecorators,
+    childrenField: 'children'
 };
 
 export default TreeBeard;

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -11,22 +11,39 @@ class TreeBeard extends React.Component {
     constructor(props){
         super(props);
     }
+    keyGetter(node, index){
+        let {keyField} = this.props;
+        if(!keyField){
+            return index;
+        }
+        else if(typeof keyField === 'function'){
+            return keyField(node);
+        }
+        return node[keyField];
+    }
+    childrenGetter(node){
+        let {childrenField} = this.props;
+        if(typeof childrenField === 'function'){
+            return childrenField(node);
+        }
+        return node[childrenField];
+    }
     render(){
-        let {data, keyField} = this.props;
+        let {data} = this.props;
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
         if(!Array.isArray(data)){ data = [data]; }
         return (
             <ul style={this.props.style.tree.base} ref="treeBase">
                 {data.map((node, index) =>
                     <TreeNode
-                        key={keyField?node[keyField]:index}
+                        key={this.keyGetter(node, index)}
                         node={node}
                         onToggle={this.props.onToggle}
                         animations={this.props.animations}
                         decorators={this.props.decorators}
                         style={this.props.style.tree.node}
-                        childrenField={this.props.childrenField}
-                        keyField={keyField}
+                        childrenGetter={this.childrenGetter.bind(this)}
+                        keyGetter={this.keyGetter.bind(this)}
                     />
                 )}
             </ul>
@@ -42,9 +59,7 @@ TreeBeard.propTypes = {
     ]).isRequired,
     animations: React.PropTypes.object,
     onToggle: React.PropTypes.func,
-    decorators: React.PropTypes.object,
-    keyField: React.PropTypes.string,
-    childrenField: React.PropTypes.string
+    decorators: React.PropTypes.object
 };
 
 TreeBeard.defaultProps = {


### PR DESCRIPTION
This will allow to set keyField or childrenField. 
<TreeBeard keyField={‚id‘} childrenField={‚items‘}/>

Also functions are possible like:
<TreeBeard keyField={x=>x.y.id} childrenField={x=>x.childs}/>