### PR TITLE
Update peerDependencies to support react v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "example": "webpack-dev-server --content-base ./example/ --config ./example/webpack.config.js"
   },
   "peerDependencies": {
-    "react": "^0.14",
-    "react-dom": "^0.14"
+    "react": "^0.14 || ^15.0",
+    "react-dom": "^0.14 || ^15.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When installing this package in a project that uses React v15 the following warning is shown:

```
npm WARN react-treebeard@1.1.1 requires a peer of react@^0.14.0 but none was installed.
npm WARN react-treebeard@1.1.1 requires a peer of react@^0.14.0 but none was installed.
```

This pr solves that.