### PR TITLE
Make compatible with 'React v15.5.0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,27 +82,27 @@ ReactDOM.render(<TreeExample/>, content);
 ### Prop Values
 
 #### data
-`React.PropTypes.oneOfType([React.PropTypes.object,React.PropTypes.array]).isRequired`
+`PropTypes.oneOfType([PropTypes.object,PropTypes.array]).isRequired`
 
 Data that drives the tree view. State-driven effects can be built by manipulating the attributes in this object. Also supports an array for multiple nodes at the root level. An example can be found in `example/data.js`
 
 #### onToggle
-`React.PropTypes.func`
+`PropTypes.func`
 
 Callback function when a node is toggled / clicked. Passes 2 attributes: the data node and it's toggled boolean state.
 
 #### style
-`React.PropTypes.object`
+`PropTypes.object`
 
 Sets the treeview styling. Defaults to `src/themes/default`.
 
 #### animations
-`React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.bool])`
+`PropTypes.oneOfType([PropTypes.object, PropTypes.bool])`
 
 Sets the treeview animations. Set to `false` if you want to turn off animations. See [velocity-react](https://github.com/twitter-fabric/velocity-react) for more details. Defaults to `src/themes/animations`.
 
 #### decorators
-`React.PropTypes.object`
+`PropTypes.object`
 
 Decorates the treeview. Here you can use your own Container, Header, Toggle and Loading components. Defaults to `src/decorators`. See example below:
 

--- a/example/app.js
+++ b/example/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { StyleRoot } from 'radium';
 import {Treebeard, decorators} from '../src/index';
@@ -44,7 +45,7 @@ class NodeViewer extends React.Component {
 }
 
 NodeViewer.propTypes = {
-    node: React.PropTypes.object
+    node: PropTypes.object
 };
 
 class DemoTree extends React.Component {

--- a/example/app.js
+++ b/example/app.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { StyleRoot } from 'radium';
+import {StyleRoot} from 'radium';
 import {Treebeard, decorators} from '../src/index';
 
 import data from './data';
@@ -13,87 +13,96 @@ import * as filters from './filter';
 const HELP_MSG = 'Select A Node To See Its Data Structure Here...';
 
 // Example: Customising The Header Decorator To Include Icons
-decorators.Header = (props) => {
-    const style = props.style;
-    const iconType = props.node.children ? 'folder' : 'file-text';
+decorators.Header = ({style, node}) => {
+    const iconType = node.children ? 'folder' : 'file-text';
     const iconClass = `fa fa-${iconType}`;
-    const iconStyle = { marginRight: '5px' };
+    const iconStyle = {marginRight: '5px'};
+
     return (
         <div style={style.base}>
             <div style={style.title}>
                 <i className={iconClass} style={iconStyle}/>
-                {props.node.name}
+
+                {node.name}
             </div>
         </div>
     );
 };
 
 class NodeViewer extends React.Component {
-    constructor(props){
-        super(props);
-    }
-    render(){
+    render() {
         const style = styles.viewer;
         let json = JSON.stringify(this.props.node, null, 4);
-        if(!json){ json = HELP_MSG; }
-        return (
-            <div style={style.base}>
-                {json}
-            </div>
-        );
+
+        if (!json) {
+            json = HELP_MSG;
+        }
+
+        return <div style={style.base}>{json}</div>;
     }
 }
-
 NodeViewer.propTypes = {
     node: PropTypes.object
 };
 
 class DemoTree extends React.Component {
-    constructor(props){
-        super(props);
+    constructor() {
+        super();
+
         this.state = {data};
         this.onToggle = this.onToggle.bind(this);
     }
-    onToggle(node, toggled){
-        if(this.state.cursor){this.state.cursor.active = false;}
+
+    onToggle(node, toggled) {
+        const {cursor} = this.state;
+
+        if (cursor) {
+            cursor.active = false;
+        }
+
         node.active = true;
-        if(node.children){ node.toggled = toggled; }
-        this.setState({ cursor: node });
+        if (node.children) {
+            node.toggled = toggled;
+        }
+
+        this.setState({cursor: node});
     }
-    onFilterMouseUp(e){
+
+    onFilterMouseUp(e) {
         const filter = e.target.value.trim();
-        if(!filter){ return this.setState({data}); }
+        if (!filter) {
+            return this.setState({data});
+        }
         var filtered = filters.filterTree(data, filter);
         filtered = filters.expandFilteredNodes(filtered, filter);
         this.setState({data: filtered});
     }
-    render(){
+
+    render() {
+        const {data: stateData, cursor} = this.state;
+
         return (
             <StyleRoot>
                 <div style={styles.searchBox}>
                     <div className="input-group">
                         <span className="input-group-addon">
-                          <i className="fa fa-search"></i>
+                          <i className="fa fa-search"/>
                         </span>
-                        <input type="text"
-                            className="form-control"
-                            placeholder="Search the tree..."
-                            onKeyUp={this.onFilterMouseUp.bind(this)}
-                        />
+                        <input className="form-control"
+                               onKeyUp={this.onFilterMouseUp.bind(this)}
+                               placeholder="Search the tree..."
+                               type="text"/>
                     </div>
                 </div>
                 <div style={styles.component}>
-                    <Treebeard
-                        data={this.state.data}
-                        onToggle={this.onToggle}
-                        decorators={decorators}
-                    />
+                    <Treebeard data={stateData}
+                               decorators={decorators}
+                               onToggle={this.onToggle}/>
                 </div>
                 <div style={styles.component}>
-                    <NodeViewer node={this.state.cursor}/>
+                    <NodeViewer node={cursor}/>
                 </div>
             </StyleRoot>
-
         );
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "prepublish": "npm run lib",
     "lib": "npm run babel",
     "babel": "rimraf lib && babel src/ -d lib/",
-    "test": "./node_modules/.bin/karma start karma.conf.js",
-    "test-travis": "./node_modules/karma/bin/karma start --browsers Firefox --single-run",
+    "test": "karma start karma.conf.js",
+    "test-travis": "karma/bin/karma start --browsers Firefox --single-run",
     "example": "webpack-dev-server --content-base ./example/ --config ./example/webpack.config.js"
   },
   "peerDependencies": {
-    "react": "^0.14 || ^15.0",
-    "react-dom": "^0.14 || ^15.0"
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0"
   },
   "repository": {
     "type": "git",
@@ -60,9 +60,9 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
     "node-libs-browser": "^0.5.3",
-    "react": "^0.14.7",
-    "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "react": "^15.3.0",
+    "react-addons-test-utils": "^15.3.0",
+    "react-dom": "^15.3.0",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.4",
     "sinon": "uberVU/Sinon.JS.git",
@@ -73,8 +73,8 @@
   "dependencies": {
     "babel-runtime": "^5.8.29",
     "deep-equal": "^1.0.1",
-    "radium": "^0.18.0",
+    "radium": "^0.18.2",
     "shallowequal": "^0.2.2",
-    "velocity-react": "^1.1.2"
+    "velocity-react": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "babel-runtime": "^5.8.29",
     "deep-equal": "^1.0.1",
+    "prop-types": "^15.5.8",
     "radium": "^0.18.2",
     "shallowequal": "^0.2.2",
     "velocity-react": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-runtime": "^5.8.29",
     "deep-equal": "^1.0.1",
     "prop-types": "^15.5.8",
-    "radium": "^0.18.2",
+    "radium": "^0.18.3",
     "shallowequal": "^0.2.2",
     "velocity-react": "^1.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "example": "webpack-dev-server --content-base ./example/ --config ./example/webpack.config.js"
   },
   "peerDependencies": {
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "repository": {
     "type": "git",
@@ -60,9 +60,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
     "node-libs-browser": "^0.5.3",
-    "react": "^15.3.0",
-    "react-addons-test-utils": "^15.3.0",
-    "react-dom": "^15.3.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.4",
     "sinon": "uberVU/Sinon.JS.git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "npm run babel",
     "babel": "rimraf lib && babel src/ -d lib/",
     "test": "karma start karma.conf.js",
-    "test-travis": "karma/bin/karma start --browsers Firefox --single-run",
+    "test-travis": "karma start --browsers Firefox --single-run",
     "example": "webpack-dev-server --content-base ./example/ --config ./example/webpack.config.js"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-runtime": "^5.8.29",
     "deep-equal": "^1.0.1",
     "prop-types": "^15.5.8",
-    "radium": "^0.18.3",
+    "radium": "^0.19.0",
     "shallowequal": "^0.2.2",
     "velocity-react": "^1.3.1"
   }

--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import Radium from 'radium';
 import {VelocityComponent} from 'velocity-react';
 
@@ -13,7 +14,7 @@ const Loading = (props) => {
 };
 
 Loading.propTypes = {
-    style: React.PropTypes.object
+    style: PropTypes.object
 };
 
 const Toggle = (props) => {
@@ -37,7 +38,7 @@ const Toggle = (props) => {
 };
 
 Toggle.propTypes = {
-    style: React.PropTypes.object
+    style: PropTypes.object
 };
 
 const Header = (props) => {
@@ -52,8 +53,8 @@ const Header = (props) => {
 };
 
 Header.propTypes = {
-    style: React.PropTypes.object,
-    node: React.PropTypes.object.isRequired
+    style: PropTypes.object,
+    node: PropTypes.object.isRequired
 };
 
 @Radium
@@ -94,15 +95,15 @@ class Container extends React.Component {
 }
 
 Container.propTypes = {
-    style: React.PropTypes.object.isRequired,
-    decorators: React.PropTypes.object.isRequired,
-    terminal: React.PropTypes.bool.isRequired,
-    onClick: React.PropTypes.func.isRequired,
-    animations: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.bool
+    style: PropTypes.object.isRequired,
+    decorators: PropTypes.object.isRequired,
+    terminal: PropTypes.bool.isRequired,
+    onClick: PropTypes.func.isRequired,
+    animations: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.bool
     ]).isRequired,
-    node: React.PropTypes.object.isRequired
+    node: PropTypes.object.isRequired
 };
 
 export default {

--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -5,53 +5,42 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import {VelocityComponent} from 'velocity-react';
 
-const Loading = (props) => {
-    return (
-        <div style={props.style}>
-            loading...
-        </div>
-    );
+const Loading = ({style}) => {
+    return <div style={style}>loading...</div>;
 };
-
 Loading.propTypes = {
     style: PropTypes.object
 };
 
-const Toggle = (props) => {
-    const style = props.style;
-    const height = style.height;
-    const width = style.width;
-    let midHeight = height * 0.5;
-    let points = `0,0 0,${height} ${width},${midHeight}`;
+const Toggle = ({style}) => {
+    const {height, width} = style;
+    const midHeight = height * 0.5;
+    const points = `0,0 0,${height} ${width},${midHeight}`;
+
     return (
         <div style={style.base}>
             <div style={style.wrapper}>
                 <svg height={height} width={width}>
-                    <polygon
-                        points={points}
-                        style={style.arrow}
-                    />
+                    <polygon points={points}
+                             style={style.arrow}/>
                 </svg>
             </div>
         </div>
     );
 };
-
 Toggle.propTypes = {
     style: PropTypes.object
 };
 
-const Header = (props) => {
-    const style = props.style;
+const Header = ({node, style}) => {
     return (
         <div style={style.base}>
             <div style={style.title}>
-                {props.node.name}
+                {node.name}
             </div>
         </div>
     );
 };
-
 Header.propTypes = {
     style: PropTypes.object,
     node: PropTypes.object.isRequired
@@ -59,41 +48,43 @@ Header.propTypes = {
 
 @Radium
 class Container extends React.Component {
-    constructor(props){
-        super(props);
-    }
-    render(){
+    render() {
         const {style, decorators, terminal, onClick, node} = this.props;
+
         return (
-            <div
-                ref="clickable"
-                onClick={onClick}
-                style={style.container}>
-                { !terminal ? this.renderToggle() : null }
-                <decorators.Header
-                    node={node}
-                    style={style.header}
-                />
+            <div onClick={onClick}
+                 ref={ref => this.clickableRef = ref}
+                 style={style.container}>
+                {!terminal ? this.renderToggle() : null}
+
+                <decorators.Header node={node}
+                                   style={style.header}/>
             </div>
         );
     }
-    renderToggle(){
-        const animations = this.props.animations;
-        if(!animations){ return this.renderToggleDecorator(); }
+
+    renderToggle() {
+        const {animations} = this.props;
+
+        if (!animations) {
+            return this.renderToggleDecorator();
+        }
+
         return (
-            <VelocityComponent ref="velocity"
-                duration={animations.toggle.duration}
-                animation={animations.toggle.animation}>
+            <VelocityComponent animation={animations.toggle.animation}
+                               duration={animations.toggle.duration}
+                               ref={ref => this.velocityRef = ref}>
                 {this.renderToggleDecorator()}
             </VelocityComponent>
         );
     }
-    renderToggleDecorator(){
+
+    renderToggleDecorator() {
         const {style, decorators} = this.props;
-        return (<decorators.Toggle style={style.toggle}/>);
+
+        return <decorators.Toggle style={style.toggle}/>;
     }
 }
-
 Container.propTypes = {
     style: PropTypes.object.isRequired,
     decorators: PropTypes.object.isRequired,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -6,35 +6,39 @@ import shallowEqual from 'shallowequal';
 import deepEqual from 'deep-equal';
 
 class NodeHeader extends React.Component {
-    constructor(props){
-        super(props);
-    }
-    shouldComponentUpdate(nextProps){
+    shouldComponentUpdate(nextProps) {
         const props = this.props;
         const nextPropKeys = Object.keys(nextProps);
-        for(let i = 0; i < nextPropKeys.length; i++){
+
+        for (let i = 0; i < nextPropKeys.length; i++) {
             const key = nextPropKeys[i];
-            if(key === 'animations'){ continue; }
+            if (key === 'animations') {
+                continue;
+            }
+
             const isEqual = shallowEqual(props[key], nextProps[key]);
-            if(!isEqual){ return true; }
+            if (!isEqual) {
+                return true;
+            }
         }
-        return !deepEqual(props.animations, nextProps.animations, { strict: true });
+
+        return !deepEqual(props.animations, nextProps.animations, {strict: true});
     }
-    render(){
-        const {style, decorators} = this.props;
-        const terminal = !this.props.node.children;
-        const active = this.props.node.active;
+
+    render() {
+        const {animations, decorators, node, onClick, style} = this.props;
+        const {active, children} = node;
+        const terminal = !children;
         const container = [style.link, active ? style.activeLink : null];
-        const headerStyles = Object.assign({ container }, this.props.style);
+        const headerStyles = Object.assign({container}, style);
+
         return (
-            <decorators.Container
-                style={headerStyles}
-                decorators={decorators}
-                terminal={terminal}
-                onClick={this.props.onClick}
-                animations={this.props.animations}
-                node={this.props.node}
-            />
+            <decorators.Container animations={animations}
+                                  decorators={decorators}
+                                  node={node}
+                                  onClick={onClick}
+                                  style={headerStyles}
+                                  terminal={terminal}/>
         );
     }
 }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import shallowEqual from 'shallowequal';
 import deepEqual from 'deep-equal';
 
@@ -39,14 +40,14 @@ class NodeHeader extends React.Component {
 }
 
 NodeHeader.propTypes = {
-    style: React.PropTypes.object.isRequired,
-    decorators: React.PropTypes.object.isRequired,
-    animations: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.bool
+    style: PropTypes.object.isRequired,
+    decorators: PropTypes.object.isRequired,
+    animations: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.bool
     ]).isRequired,
-    node: React.PropTypes.object.isRequired,
-    onClick: React.PropTypes.func
+    node: PropTypes.object.isRequired,
+    onClick: PropTypes.func
 };
 
 export default NodeHeader;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {VelocityTransitionGroup} from 'velocity-react';
 
 import NodeHeader from './header';
@@ -97,14 +98,14 @@ class TreeNode extends React.Component {
 }
 
 TreeNode.propTypes = {
-    style: React.PropTypes.object.isRequired,
-    node: React.PropTypes.object.isRequired,
-    decorators: React.PropTypes.object.isRequired,
-    animations: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.bool
+    style: PropTypes.object.isRequired,
+    node: PropTypes.object.isRequired,
+    decorators: PropTypes.object.isRequired,
+    animations: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.bool
     ]).isRequired,
-    onToggle: React.PropTypes.func
+    onToggle: PropTypes.func
 };
 
 export default TreeNode;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -7,93 +7,132 @@ import {VelocityTransitionGroup} from 'velocity-react';
 import NodeHeader from './header';
 
 class TreeNode extends React.Component {
-    constructor(props){
-        super(props);
+    constructor() {
+        super();
+
         this.onClick = this.onClick.bind(this);
     }
-    onClick(){
-        let toggled = !this.props.node.toggled;
-        let onToggle = this.props.onToggle;
-        if(onToggle){ onToggle(this.props.node, toggled); }
+
+    onClick() {
+        const {node, onToggle} = this.props;
+        const {toggled} = node;
+
+        if (onToggle) {
+            onToggle(node, !toggled);
+        }
     }
-    animations(){
-        const props = this.props;
-        if(props.animations === false){ return false; }
-        let anim = Object.assign({}, props.animations, props.node.animations);
+
+    animations() {
+        const {animations, node} = this.props;
+
+        if (animations === false) {
+            return false;
+        }
+
+        const anim = Object.assign({}, animations, node.animations);
         return {
             toggle: anim.toggle(this.props),
             drawer: anim.drawer(this.props)
         };
     }
-    decorators(){
+
+    decorators() {
         // Merge Any Node Based Decorators Into The Pack
-        const props = this.props;
-        let nodeDecorators = props.node.decorators || {};
-        return Object.assign({}, props.decorators, nodeDecorators);
+        const {decorators, node} = this.props;
+        let nodeDecorators = node.decorators || {};
+
+        return Object.assign({}, decorators, nodeDecorators);
     }
-    render(){
+
+    render() {
+        const {style} = this.props;
         const decorators = this.decorators();
         const animations = this.animations();
+
         return (
-            <li style={this.props.style.base} ref="topLevel">
+            <li ref={ref => this.topLevelRef = ref}
+                style={style.base}>
                 {this.renderHeader(decorators, animations)}
+
                 {this.renderDrawer(decorators, animations)}
             </li>
         );
     }
-    renderDrawer(decorators, animations){
-        const toggled = this.props.node.toggled;
-        if(!animations && !toggled){ return null; }
-        if(!animations && toggled){
+
+    renderDrawer(decorators, animations) {
+        const {node: {toggled}} = this.props;
+
+        if (!animations && !toggled) {
+            return null;
+        } else if (!animations && toggled) {
             return this.renderChildren(decorators, animations);
         }
+
+        const {animation, duration, ...restAnimationInfo} = animations.drawer;
         return (
-            <VelocityTransitionGroup {...animations.drawer} ref="velocity">
+            <VelocityTransitionGroup {...restAnimationInfo}
+                                     ref={ref => this.velocityRef = ref}>
                 {toggled ? this.renderChildren(decorators, animations) : null}
             </VelocityTransitionGroup>
         );
     }
-    renderHeader(decorators, animations){
+
+    renderHeader(decorators, animations) {
+        const {node, style} = this.props;
+
         return (
-            <NodeHeader
-                decorators={decorators}
-                animations={animations}
-                style={this.props.style}
-                node={Object.assign({}, this.props.node)}
-                onClick={this.onClick}
-            />
+            <NodeHeader animations={animations}
+                        decorators={decorators}
+                        node={Object.assign({}, node)}
+                        onClick={this.onClick}
+                        style={style}/>
         );
     }
-    renderChildren(decorators){
-        if(this.props.node.loading){ return this.renderLoading(decorators); }
-        let children = this.props.node.children;
-        if (!Array.isArray(children)) { children = children ? [children] : []; }
+
+    renderChildren(decorators) {
+        const {animations, decorators: propDecorators, node, style} = this.props;
+
+        if (node.loading) {
+            return this.renderLoading(decorators);
+        }
+
+        let children = node.children;
+        if (!Array.isArray(children)) {
+            children = children ? [children] : [];
+        }
+
         return (
-            <ul style={this.props.style.subtree} ref="subtree">
-                {children.map((child, index) =>
-                    <TreeNode
-                        {...this._eventBubbles()}
-                        key={child.id || index}
-                        node={child}
-                        decorators={this.props.decorators}
-                        animations={this.props.animations}
-                        style={this.props.style}
-                    />
+            <ul style={style.subtree}
+                ref={ref => this.subtreeRef = ref}>
+                {children.map((child, index) => <TreeNode {...this._eventBubbles()}
+                                                          animations={animations}
+                                                          decorators={propDecorators}
+                                                          key={child.id || index}
+                                                          node={child}
+                                                          style={style}/>
                 )}
             </ul>
         );
     }
-    renderLoading(decorators){
+
+    renderLoading(decorators) {
+        const {style} = this.props;
+
         return (
-            <ul style={this.props.style.subtree}>
+            <ul style={style.subtree}>
                 <li>
-                    <decorators.Loading style={this.props.style.loading}/>
+                    <decorators.Loading style={style.loading}/>
                 </li>
             </ul>
         );
     }
-    _eventBubbles(){
-        return { onToggle: this.props.onToggle };
+
+    _eventBubbles() {
+        const {onToggle} = this.props;
+
+        return {
+            onToggle
+        };
     }
 }
 

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -9,24 +9,24 @@ import defaultTheme from '../themes/default';
 import defaultAnimations from '../themes/animations';
 
 class TreeBeard extends React.Component {
-    constructor(props){
-        super(props);
-    }
-    render(){
-        let data = this.props.data;
+    render() {
+        const {animations, decorators, data: propsData, onToggle, style} = this.props;
+        let data = propsData;
+
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
-        if(!Array.isArray(data)){ data = [data]; }
+        if (!Array.isArray(data)) {
+            data = [data];
+        }
         return (
-            <ul style={this.props.style.tree.base} ref="treeBase">
+            <ul style={style.tree.base}
+                ref={ref => this.treeBaseRef = ref}>
                 {data.map((node, index) =>
-                    <TreeNode
-                        key={node.id || index}
-                        node={node}
-                        onToggle={this.props.onToggle}
-                        animations={this.props.animations}
-                        decorators={this.props.decorators}
-                        style={this.props.style.tree.node}
-                    />
+                    <TreeNode animations={animations}
+                              decorators={decorators}
+                              key={node.id || index}
+                              node={node}
+                              onToggle={onToggle}
+                              style={style.tree.node}/>
                 )}
             </ul>
         );

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import TreeNode from './node';
 import defaultDecorators from './decorators';
@@ -33,17 +34,17 @@ class TreeBeard extends React.Component {
 }
 
 TreeBeard.propTypes = {
-    style: React.PropTypes.object,
-    data: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.array
+    style: PropTypes.object,
+    data: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array
     ]).isRequired,
-    animations: React.PropTypes.oneOfType([
-        React.PropTypes.object,
-        React.PropTypes.bool
+    animations: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.bool
     ]),
-    onToggle: React.PropTypes.func,
-    decorators: React.PropTypes.object
+    onToggle: PropTypes.func,
+    decorators: PropTypes.object
 };
 
 TreeBeard.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,13 @@
 'use strict';
-module.exports = {
-    Treebeard: require('./components/treebeard'),
-    decorators: require('./components/decorators'),
-    animations: require('./themes/animations'),
-    theme: require('./themes/default')
+
+import Treebeard from './components/treebeard';
+import decorators from './components/decorators';
+import animations from './themes/animations';
+import theme from './themes/default';
+
+export default {
+    Treebeard,
+    decorators,
+    animations,
+    theme
 };

--- a/src/themes/animations.js
+++ b/src/themes/animations.js
@@ -1,7 +1,7 @@
 'use strict';
 
 export default {
-    toggle: ({node: toggled}) => ({
+    toggle: ({node: {toggled}}) => ({
         animation: {rotateZ: toggled ? 90 : 0},
         duration: 300
     }),

--- a/src/themes/animations.js
+++ b/src/themes/animations.js
@@ -1,22 +1,18 @@
 'use strict';
 
 export default {
-    toggle: (props) => {
-        return {
-            animation: { rotateZ: props.node.toggled ? 90 : 0 },
+    toggle: ({node: toggled}) => ({
+        animation: {rotateZ: toggled ? 90 : 0},
+        duration: 300
+    }),
+    drawer: (/* props */) => ({
+        enter: {
+            animation: 'slideDown',
             duration: 300
-        };
-    },
-    drawer: (/* props */) => {
-        return {
-            enter: {
-                animation: 'slideDown',
-                duration: 300
-            },
-            leave: {
-                animation: 'slideUp',
-                duration: 300
-            }
-        };
-    }
+        },
+        leave: {
+            animation: 'slideUp',
+            duration: 300
+        }
+    })
 };

--- a/test/src/components/decorator-tests.js
+++ b/test/src/components/decorator-tests.js
@@ -11,11 +11,11 @@ const factory = require('../utils/factory');
 
 const defaults = {
     style: {},
-    node: { children: [] },
-    animations: { toggle: {} },
+    node: {children: []},
+    animations: {toggle: {}},
     terminal: false,
     decorators: factory.createDecorators(),
-    onClick: function(){}
+    onClick: () => null
 };
 
 const Container = defaultDecorators.Container;
@@ -25,21 +25,21 @@ describe('container decorator component', () => {
         const onClick = sinon.spy();
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                onClick={onClick}
+                       onClick={onClick}
             />
         );
-        const clickable = container.refs.clickable;
+        const clickable = container.clickableRef;
         TestUtils.Simulate.click(clickable);
         onClick.should.be.called.once;
     });
 
     it('should render the toggle decorator not terminal', () => {
-        const toggleType = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ toggle: toggleType });
+        const toggleType = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                decorators={decorators}
-                terminal={false}
+                       decorators={decorators}
+                       terminal={false}
             />
         );
         const toggle = TestUtils.findRenderedComponentWithType(container, toggleType);
@@ -47,12 +47,12 @@ describe('container decorator component', () => {
     });
 
     it('should not render the toggle decorator if the node is terminal', () => {
-        const toggleType = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ toggle: toggleType });
+        const toggleType = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                decorators={decorators}
-                terminal={true}
+                       decorators={decorators}
+                       terminal={true}
             />
         );
         const toggle = TestUtils.scryRenderedComponentsWithType(container, toggleType);
@@ -60,13 +60,13 @@ describe('container decorator component', () => {
     });
 
     it('should pass the style to the toggle decorator', () => {
-        const style = { toggle: { color: 'red' } };
-        const toggleType = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ toggle: toggleType });
+        const style = {toggle: {color: 'red'}};
+        const toggleType = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                decorators={decorators}
-                style={style}
+                       decorators={decorators}
+                       style={style}
             />
         );
         const toggle = TestUtils.findRenderedComponentWithType(container, toggleType);
@@ -84,10 +84,10 @@ describe('container decorator component', () => {
     it('should not render a velocity component if animations is false', () => {
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                animations={false}
+                       animations={false}
             />
         );
-        const velocity = container.refs.velocity;
+        const velocity = container.velocityRef;
         global.should.not.exist(velocity);
     });
 
@@ -95,31 +95,31 @@ describe('container decorator component', () => {
         const animations = factory.createAnimations();
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                animations={animations}
+                       animations={animations}
             />
         );
-        const velocity = container.refs.velocity;
+        const velocity = container.velocityRef;
         velocity.should.exist;
     });
 
     it('should pass velocity the toggle animation and duration props', () => {
-        const animations = { toggle: { duration: 1, animation: 'slideUp' } };
+        const animations = {toggle: {duration: 1, animation: 'slideUp'}};
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                animations={animations}
+                       animations={animations}
             />
         );
-        const velocity = container.refs.velocity;
+        const velocity = container.velocityRef;
         velocity.props.duration.should.equal(animations.toggle.duration);
         velocity.props.animation.should.equal(animations.toggle.animation);
     });
 
     it('should render the header decorator', () => {
-        const headType = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ header: headType });
+        const headType = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                decorators={decorators}
+                       decorators={decorators}
             />
         );
         const head = TestUtils.findRenderedComponentWithType(container, headType);
@@ -127,15 +127,15 @@ describe('container decorator component', () => {
     });
 
     it('should pass the node and style to the header decorator', () => {
-        const style = { header: { color: 'red' } };
-        const node = { name: 'terminal-node' };
-        const headType = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ header: headType });
+        const style = {header: {color: 'red'}};
+        const node = {name: 'terminal-node'};
+        const headType = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                decorators={decorators}
-                node={node}
-                style={style}
+                       decorators={decorators}
+                       node={node}
+                       style={style}
             />
         );
         const head = TestUtils.findRenderedComponentWithType(container, headType);

--- a/test/src/components/decorator-tests.js
+++ b/test/src/components/decorator-tests.js
@@ -2,19 +2,19 @@
 
 'use strict';
 
-const sinon = require('sinon');
-const React = require('react');
-const TestUtils = require('react-dom/test-utils');
-const VelocityComponent = require('velocity-react').VelocityComponent;
-const defaultDecorators = require('../../../src/components/decorators');
-const factory = require('../utils/factory');
+import sinon from 'sinon';
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import {VelocityComponent} from 'velocity-react';
+import defaultDecorators from '../../../src/components/decorators';
+import {createAnimations, createDecorators} from '../utils/factory';
 
 const defaults = {
     style: {},
     node: {children: []},
     animations: {toggle: {}},
     terminal: false,
-    decorators: factory.createDecorators(),
+    decorators: createDecorators(),
     onClick: () => null
 };
 
@@ -39,7 +39,7 @@ describe('container decorator component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({toggle: toggleType});
+        const decorators = createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
@@ -56,7 +56,7 @@ describe('container decorator component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({toggle: toggleType});
+        const decorators = createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
@@ -74,7 +74,7 @@ describe('container decorator component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({toggle: toggleType});
+        const decorators = createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
@@ -104,7 +104,7 @@ describe('container decorator component', () => {
     });
 
     it('should render a velocity component if animations is an object', () => {
-        const animations = factory.createAnimations();
+        const animations = createAnimations();
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        animations={animations}
@@ -132,7 +132,7 @@ describe('container decorator component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({header: headType});
+        const decorators = createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
@@ -150,13 +150,12 @@ describe('container decorator component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({header: headType});
+        const decorators = createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
                        node={node}
-                       style={style}
-            />
+                       style={style}/>
         );
         const head = TestUtils.findRenderedComponentWithType(container, headType);
         head.props.style.should.equal(style.header);

--- a/test/src/components/decorator-tests.js
+++ b/test/src/components/decorator-tests.js
@@ -34,7 +34,11 @@ describe('container decorator component', () => {
     });
 
     it('should render the toggle decorator not terminal', () => {
-        const toggleType = React.createClass({render: () => <div/>});
+        class toggleType extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
@@ -47,7 +51,11 @@ describe('container decorator component', () => {
     });
 
     it('should not render the toggle decorator if the node is terminal', () => {
-        const toggleType = React.createClass({render: () => <div/>});
+        class toggleType extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
@@ -61,7 +69,11 @@ describe('container decorator component', () => {
 
     it('should pass the style to the toggle decorator', () => {
         const style = {toggle: {color: 'red'}};
-        const toggleType = React.createClass({render: () => <div/>});
+        class toggleType extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({toggle: toggleType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
@@ -115,7 +127,11 @@ describe('container decorator component', () => {
     });
 
     it('should render the header decorator', () => {
-        const headType = React.createClass({render: () => <div/>});
+        class headType extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
@@ -129,7 +145,11 @@ describe('container decorator component', () => {
     it('should pass the node and style to the header decorator', () => {
         const style = {header: {color: 'red'}};
         const node = {name: 'terminal-node'};
-        const headType = React.createClass({render: () => <div/>});
+        class headType extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}

--- a/test/src/components/decorator-tests.js
+++ b/test/src/components/decorator-tests.js
@@ -2,11 +2,14 @@
 
 'use strict';
 
-import sinon from 'sinon';
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
+
 import {VelocityComponent} from 'velocity-react';
+import sinon from 'sinon';
+
 import defaultDecorators from '../../../src/components/decorators';
+
 import {createAnimations, createDecorators} from '../utils/factory';
 
 const defaults = {
@@ -25,11 +28,11 @@ describe('container decorator component', () => {
         const onClick = sinon.spy();
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                       onClick={onClick}
-            />
+                       onClick={onClick}/>
         );
         const clickable = container.clickableRef;
         TestUtils.Simulate.click(clickable);
+
         onClick.should.be.called.once;
     });
 
@@ -43,10 +46,10 @@ describe('container decorator component', () => {
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
-                       terminal={false}
-            />
+                       terminal={false}/>
         );
         const toggle = TestUtils.findRenderedComponentWithType(container, toggleType);
+
         toggle.should.exist;
     });
 
@@ -60,10 +63,10 @@ describe('container decorator component', () => {
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
-                       terminal={true}
-            />
+                       terminal={true}/>
         );
         const toggle = TestUtils.scryRenderedComponentsWithType(container, toggleType);
+
         toggle.should.be.empty;
     });
 
@@ -78,28 +81,27 @@ describe('container decorator component', () => {
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
                        decorators={decorators}
-                       style={style}
-            />
+                       style={style}/>
         );
         const toggle = TestUtils.findRenderedComponentWithType(container, toggleType);
+
         toggle.props.style.should.equal(style.toggle);
     });
 
     it('should render the toggle decorator in a velocity component', () => {
-        const container = TestUtils.renderIntoDocument(
-            <Container {...defaults}/>
-        );
+        const container = TestUtils.renderIntoDocument(<Container {...defaults}/>);
         const component = TestUtils.findRenderedComponentWithType(container, VelocityComponent);
+
         component.should.exist;
     });
 
     it('should not render a velocity component if animations is false', () => {
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                       animations={false}
-            />
+                       animations={false}/>
         );
         const velocity = container.velocityRef;
+
         global.should.not.exist(velocity);
     });
 
@@ -107,10 +109,10 @@ describe('container decorator component', () => {
         const animations = createAnimations();
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                       animations={animations}
-            />
+                       animations={animations}/>
         );
         const velocity = container.velocityRef;
+
         velocity.should.exist;
     });
 
@@ -118,10 +120,10 @@ describe('container decorator component', () => {
         const animations = {toggle: {duration: 1, animation: 'slideUp'}};
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                       animations={animations}
-            />
+                       animations={animations}/>
         );
         const velocity = container.velocityRef;
+
         velocity.props.duration.should.equal(animations.toggle.duration);
         velocity.props.animation.should.equal(animations.toggle.animation);
     });
@@ -135,10 +137,10 @@ describe('container decorator component', () => {
         const decorators = createDecorators({header: headType});
         const container = TestUtils.renderIntoDocument(
             <Container {...defaults}
-                       decorators={decorators}
-            />
+                       decorators={decorators}/>
         );
         const head = TestUtils.findRenderedComponentWithType(container, headType);
+
         head.should.exist;
     });
 
@@ -158,6 +160,7 @@ describe('container decorator component', () => {
                        style={style}/>
         );
         const head = TestUtils.findRenderedComponentWithType(container, headType);
+
         head.props.style.should.equal(style.header);
         head.props.node.should.equal(node);
     });

--- a/test/src/components/decorator-tests.js
+++ b/test/src/components/decorator-tests.js
@@ -4,7 +4,7 @@
 
 const sinon = require('sinon');
 const React = require('react');
-const TestUtils = require('react-addons-test-utils');
+const TestUtils = require('react-dom/test-utils');
 const VelocityComponent = require('velocity-react').VelocityComponent;
 const defaultDecorators = require('../../../src/components/decorators');
 const factory = require('../utils/factory');

--- a/test/src/components/header-tests.js
+++ b/test/src/components/header-tests.js
@@ -7,7 +7,11 @@ const TestUtils = require('react-dom/test-utils');
 const Header = require('../../../src/components/header');
 const factory = require('../utils/factory');
 
-const ContainerType = React.createClass({render: () => <div/>});
+class ContainerType extends React.Component {
+    render() {
+        return <div/>;
+    }
+}
 
 const defaults = {
     style: {},

--- a/test/src/components/header-tests.js
+++ b/test/src/components/header-tests.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-const React = require('react');
-const TestUtils = require('react-dom/test-utils');
-const Header = require('../../../src/components/header');
-const factory = require('../utils/factory');
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import Header from '../../../src/components/header';
+import {createDecorators} from '../utils/factory';
 
 class ContainerType extends React.Component {
     render() {
@@ -17,7 +17,7 @@ const defaults = {
     style: {},
     node: {children: []},
     animations: {toggle: {}},
-    decorators: factory.createDecorators({container: ContainerType})
+    decorators: createDecorators({container: ContainerType})
 };
 
 describe('header component', () => {

--- a/test/src/components/header-tests.js
+++ b/test/src/components/header-tests.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const React = require('react');
-const TestUtils = require('react-addons-test-utils');
+const TestUtils = require('react-dom/test-utils');
 const Header = require('../../../src/components/header');
 const factory = require('../utils/factory');
 

--- a/test/src/components/header-tests.js
+++ b/test/src/components/header-tests.js
@@ -4,7 +4,9 @@
 
 import React from 'react';
 import TestUtils from 'react-dom/test-utils';
+
 import Header from '../../../src/components/header';
+
 import {createDecorators} from '../utils/factory';
 
 class ContainerType extends React.Component {
@@ -22,10 +24,9 @@ const defaults = {
 
 describe('header component', () => {
     it('should render the container decorator', () => {
-        const header = TestUtils.renderIntoDocument(
-            <Header {...defaults}/>
-        );
+        const header = TestUtils.renderIntoDocument(<Header {...defaults}/>);
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
+
         container.should.exist;
     });
 
@@ -33,10 +34,10 @@ describe('header component', () => {
         const node = {toggled: false};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    node={node}
-            />
+                    node={node}/>
         );
         const nextProps = {node: {toggled: !node.toggled}};
+
         header.shouldComponentUpdate(nextProps).should.be.true;
     });
 
@@ -44,10 +45,10 @@ describe('header component', () => {
         const node = {toggled: false};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    node={node}
-            />
+                    node={node}/>
         );
         const nextProps = Object.assign({}, defaults, {node: {toggled: node.toggled}});
+
         header.shouldComponentUpdate(nextProps).should.be.false;
     });
 
@@ -55,11 +56,11 @@ describe('header component', () => {
         const animations = {nested: {prop: 'value'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    animations={animations}
-            />
+                    animations={animations}/>
         );
         const sameAnimationProp = {animations: {nested: {prop: animations.nested.prop}}};
         const nextProps = Object.assign({}, defaults, sameAnimationProp);
+
         header.shouldComponentUpdate(nextProps).should.be.false;
     });
 
@@ -67,11 +68,11 @@ describe('header component', () => {
         const animations = {nested: {prop: 'value'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    animations={animations}
-            />
+                    animations={animations}/>
         );
         const diffAnimationProp = {animations: {nested: {prop: 'new-value'}}};
         const nextProps = Object.assign({}, defaults, diffAnimationProp);
+
         header.shouldComponentUpdate(nextProps).should.be.true;
     });
 
@@ -79,10 +80,10 @@ describe('header component', () => {
         const node = {name: 'terminal-node'};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    node={node}
-            />
+                    node={node}/>
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
+
         container.props.terminal.should.be.true;
     });
 
@@ -90,10 +91,10 @@ describe('header component', () => {
         const node = {children: [{name: 'child-node'}]};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    node={node}
-            />
+                    node={node}/>
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
+
         container.props.terminal.should.be.false;
     });
 
@@ -101,10 +102,10 @@ describe('header component', () => {
         const style = {link: {backgroundColor: 'black'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                    style={style}
-            />
+                    style={style}/>
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
+
         container.props.style.container[0].should.equal(style.link);
     });
 
@@ -114,10 +115,10 @@ describe('header component', () => {
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
                     node={node}
-                    style={style}
-            />
+                    style={style}/>
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
+
         container.props.style.container[1].should.equal(style.activeLink);
     });
 
@@ -127,10 +128,10 @@ describe('header component', () => {
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
                     node={node}
-                    style={style}
-            />
+                    style={style}/>
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
+
         global.should.not.exist(container.props.style.container[1]);
     });
 

--- a/test/src/components/header-tests.js
+++ b/test/src/components/header-tests.js
@@ -7,13 +7,13 @@ const TestUtils = require('react-addons-test-utils');
 const Header = require('../../../src/components/header');
 const factory = require('../utils/factory');
 
-const ContainerType = React.createClass({ render: () => <div/> });
+const ContainerType = React.createClass({render: () => <div/>});
 
 const defaults = {
     style: {},
-    node: { children: [] },
-    animations: { toggle: {} },
-    decorators: factory.createDecorators({ container: ContainerType })
+    node: {children: []},
+    animations: {toggle: {}},
+    decorators: factory.createDecorators({container: ContainerType})
 };
 
 describe('header component', () => {
@@ -26,56 +26,56 @@ describe('header component', () => {
     });
 
     it('should update the component if a prop changes', () => {
-        const node = { toggled: false };
+        const node = {toggled: false};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                node={node}
+                    node={node}
             />
         );
-        const nextProps = { node: { toggled: !node.toggled } };
+        const nextProps = {node: {toggled: !node.toggled}};
         header.shouldComponentUpdate(nextProps).should.be.true;
     });
 
     it('should not update the component if no props change', () => {
-        const node = { toggled: false };
+        const node = {toggled: false};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                node={node}
+                    node={node}
             />
         );
-        const nextProps = Object.assign({}, defaults, { node: { toggled: node.toggled } });
+        const nextProps = Object.assign({}, defaults, {node: {toggled: node.toggled}});
         header.shouldComponentUpdate(nextProps).should.be.false;
     });
 
     it('should not update when deep nested animation props have not changed value', () => {
-        const animations = { nested: { prop: 'value' } };
+        const animations = {nested: {prop: 'value'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                animations={animations}
+                    animations={animations}
             />
         );
-        const sameAnimationProp = { animations: { nested: { prop: animations.nested.prop } } };
+        const sameAnimationProp = {animations: {nested: {prop: animations.nested.prop}}};
         const nextProps = Object.assign({}, defaults, sameAnimationProp);
         header.shouldComponentUpdate(nextProps).should.be.false;
     });
 
     it('should update when deep nested animation props have changed value', () => {
-        const animations = { nested: { prop: 'value' } };
+        const animations = {nested: {prop: 'value'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                animations={animations}
+                    animations={animations}
             />
         );
-        const diffAnimationProp = { animations: { nested: { prop: 'new-value' } } };
+        const diffAnimationProp = {animations: {nested: {prop: 'new-value'}}};
         const nextProps = Object.assign({}, defaults, diffAnimationProp);
         header.shouldComponentUpdate(nextProps).should.be.true;
     });
 
     it('should pass a true terminal prop to the container when there are no children in the node', () => {
-        const node = { name: 'terminal-node' };
+        const node = {name: 'terminal-node'};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                node={node}
+                    node={node}
             />
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
@@ -83,10 +83,10 @@ describe('header component', () => {
     });
 
     it('should pass a false terminal prop to the container when there are children in the node', () => {
-        const node = { children: [{ name: 'child-node'}] };
+        const node = {children: [{name: 'child-node'}]};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                node={node}
+                    node={node}
             />
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
@@ -94,10 +94,10 @@ describe('header component', () => {
     });
 
     it('should pass in the high-level link style to the container', () => {
-        const style = { link: { backgroundColor: 'black' } };
+        const style = {link: {backgroundColor: 'black'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                style={style}
+                    style={style}
             />
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
@@ -105,12 +105,12 @@ describe('header component', () => {
     });
 
     it('should pass the active link style prop to the container when the node is active', () => {
-        const node = { active: true };
-        const style = { activeLink: { color: 'red' } };
+        const node = {active: true};
+        const style = {activeLink: {color: 'red'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                node={node}
-                style={style}
+                    node={node}
+                    style={style}
             />
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);
@@ -118,12 +118,12 @@ describe('header component', () => {
     });
 
     it('should not pass the active link style prop to the container when the node is inactive', () => {
-        const node = { active: false };
-        const style = { activeLink: { color: 'red' } };
+        const node = {active: false};
+        const style = {activeLink: {color: 'red'}};
         const header = TestUtils.renderIntoDocument(
             <Header {...defaults}
-                node={node}
-                style={style}
+                    node={node}
+                    style={style}
             />
         );
         const container = TestUtils.findRenderedComponentWithType(header, ContainerType);

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -5,7 +5,7 @@
 const sinon = require('sinon');
 const React = require('react');
 const ReactDOM = require('react-dom');
-const TestUtils = require('react-addons-test-utils');
+const TestUtils = require('react-dom/test-utils');
 const TreeNode = require('../../../src/components/node');
 const factory = require('../utils/factory');
 

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -2,11 +2,15 @@
 
 'use strict';
 
-import sinon from 'sinon';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
+
+import sinon from 'sinon';
+import {VelocityTransitionGroup as TransitionGroup} from 'velocity-react';
+
+import NodeHeader from '../../../src/components/header';
 import TreeNode from '../../../src/components/node';
+
 import {createAnimations, createDecorators} from '../utils/factory';
 
 const defaults = {
@@ -18,9 +22,8 @@ const defaults = {
 
 describe('node component', () => {
     it('should not have any internal state', () => {
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults}/>
-        );
+        const treeNode = TestUtils.renderIntoDocument(<TreeNode {...defaults}/>);
+
         global.should.not.exist(treeNode.state);
     });
 
@@ -31,11 +34,9 @@ describe('node component', () => {
             done();
         };
         const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode
-                {...defaults}
-                node={node}
-                onToggle={onToggle}
-            />
+            <TreeNode {...defaults}
+                      node={node}
+                      onToggle={onToggle}/>
         );
         treeNode.onClick();
     });
@@ -49,13 +50,12 @@ describe('node component', () => {
             />
         );
         treeNode.onClick();
+
         onToggle.should.be.called.once;
     });
 
     it('should not throw an exception if a callback is not registered on click', () => {
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults}/>
-        );
+        const treeNode = TestUtils.renderIntoDocument(<TreeNode {...defaults}/>);
 
         (() => treeNode.onClick()).should.not.throw(Error);
     });
@@ -67,12 +67,11 @@ describe('node component', () => {
         };
         const node = {animations: nodeAnimations};
         const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode
-                {...defaults}
-                node={node}
-            />
+            <TreeNode{...defaults}
+                     node={node}/>
         );
         treeNode.animations();
+
         nodeAnimations.toggle.should.be.calledWith(treeNode.props);
         nodeAnimations.drawer.should.be.calledWith(treeNode.props);
     });
@@ -83,12 +82,11 @@ describe('node component', () => {
             drawer: sinon.stub().returns({duration: 0, animation: 'fadeIn'})
         };
         const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode
-                {...defaults}
-                animations={animations}
-            />
+            <TreeNode{...defaults}
+                     animations={animations}/>
         );
         treeNode.animations();
+
         animations.toggle.should.be.calledWith(treeNode.props);
         animations.drawer.should.be.calledWith(treeNode.props);
     });
@@ -104,12 +102,12 @@ describe('node component', () => {
         };
         const node = {decorators: nodeDecorators, children: []};
         const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode
-                {...defaults}
-                node={node}
-            />
+            <TreeNode {...defaults}
+                      node={node}/>
         );
-        TestUtils.findRenderedComponentWithType(treeNode, ContainerDecorator).should.exist;
+        const component = TestUtils.findRenderedComponentWithType(treeNode, ContainerDecorator);
+
+        component.should.exist;
     });
 
     it('should fallback to the prop decorators if the node decorators are not defined', () => {
@@ -123,13 +121,13 @@ describe('node component', () => {
         };
         const node = {children: []};
         const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode
-                {...defaults}
-                decorators={decorators}
-                node={node}
-            />
+            <TreeNode {...defaults}
+                      decorators={decorators}
+                      node={node}/>
         );
-        TestUtils.findRenderedComponentWithType(treeNode, ContainerDecorator).should.exist;
+        const component = TestUtils.findRenderedComponentWithType(treeNode, ContainerDecorator);
+
+        component.should.exist;
     });
 
     it('should render a list item at the top level', () => {
@@ -141,35 +139,30 @@ describe('node component', () => {
     });
 
     it('should render the NodeHeader component', () => {
-        const NodeHeader = require('../../../src/components/header');
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults}/>
-        );
-        TestUtils.findRenderedComponentWithType(treeNode, NodeHeader).should.exist;
+        const treeNode = TestUtils.renderIntoDocument(<TreeNode {...defaults}/>);
+        const component = TestUtils.findRenderedComponentWithType(treeNode, NodeHeader);
+
+        component.should.exist;
     });
 
     it('should render the subtree if toggled', () => {
         const node = {toggled: true};
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults} node={node}/>
-        );
+        const treeNode = TestUtils.renderIntoDocument(<TreeNode {...defaults} node={node}/>);
+
         treeNode.subtreeRef.should.exist;
     });
 
     it('should not render the children if not toggled', () => {
         const node = {toggled: false};
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults} node={node}/>
-        );
+        const treeNode = TestUtils.renderIntoDocument(<TreeNode {...defaults} node={node}/>);
+
         global.should.not.exist(treeNode.subtreeRef);
     });
 
     it('should wrap the children in a velocity transition group', () => {
-        const TransitionGroup = require('velocity-react').VelocityTransitionGroup;
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults}/>
-        );
+        const treeNode = TestUtils.renderIntoDocument(<TreeNode {...defaults}/>);
         const component = TestUtils.findRenderedComponentWithType(treeNode, TransitionGroup);
+
         component.should.exist;
     });
 
@@ -177,11 +170,11 @@ describe('node component', () => {
         const animations = createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                      animations={animations}
-            />
+                      animations={animations}/>
         );
         const velocity = treeNode.velocityRef;
         const drawer = animations.drawer();
+
         velocity.props.enter.animation.should.equal(drawer.enter.animation);
         velocity.props.enter.duration.should.equal(drawer.enter.duration);
     });
@@ -190,11 +183,11 @@ describe('node component', () => {
         const animations = createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                      animations={animations}
-            />
+                      animations={animations}/>
         );
         const velocity = treeNode.velocityRef;
         const drawer = animations.drawer();
+
         velocity.props.leave.animation.should.equal(drawer.leave.animation);
         velocity.props.leave.duration.should.equal(drawer.leave.duration);
     });
@@ -204,10 +197,10 @@ describe('node component', () => {
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       animations={false}
-                      node={node}
-            />
+                      node={node}/>
         );
         const velocity = treeNode.velocityRef;
+
         global.should.not.exist(velocity);
     });
 
@@ -216,10 +209,10 @@ describe('node component', () => {
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       animations={false}
-                      node={node}
-            />
+                      node={node}/>
         );
         const velocity = treeNode.velocityRef;
+
         global.should.not.exist(velocity);
     });
 
@@ -227,10 +220,10 @@ describe('node component', () => {
         const animations = createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                      animations={animations}
-            />
+                      animations={animations}/>
         );
         const velocity = treeNode.velocityRef;
+
         velocity.should.exist;
     });
 
@@ -238,10 +231,10 @@ describe('node component', () => {
         const node = {toggled: true};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                      node={node}
-            />
+                      node={node}/>
         );
         const subtree = treeNode.subtreeRef;
+
         subtree.tagName.toLowerCase().should.equal('ul');
     });
 
@@ -252,11 +245,11 @@ describe('node component', () => {
         };
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                      node={node}
-            />
+                      node={node}/>
         );
         // Find All TreeNodes (+ Top Level TreeNode)
         const nodes = TestUtils.scryRenderedComponentsWithType(treeNode, TreeNode);
+
         nodes.length.should.equal(node.children.length + 1);
     });
 
@@ -271,10 +264,10 @@ describe('node component', () => {
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       node={node}
-                      decorators={decorators}
-            />
+                      decorators={decorators}/>
         );
         const loading = TestUtils.findRenderedComponentWithType(treeNode, LoadingDecorator);
+
         loading.should.exist;
     });
 
@@ -289,10 +282,10 @@ describe('node component', () => {
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       node={node}
-                      decorators={decorators}
-            />
+                      decorators={decorators}/>
         );
         const loading = TestUtils.scryRenderedComponentsWithType(treeNode, LoadingDecorator);
+
         loading.should.be.empty;
     });
 
@@ -300,9 +293,9 @@ describe('node component', () => {
         const node = {toggled: true, loading: true};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                      node={node}
-            />
+                      node={node}/>
         );
+
         global.should.not.exist(treeNode.subtreeRef);
     });
 });

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -2,18 +2,18 @@
 
 'use strict';
 
-const sinon = require('sinon');
-const React = require('react');
-const ReactDOM = require('react-dom');
-const TestUtils = require('react-dom/test-utils');
-const TreeNode = require('../../../src/components/node');
-const factory = require('../utils/factory');
+import sinon from 'sinon';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+import TreeNode from '../../../src/components/node';
+import {createAnimations, createDecorators} from '../utils/factory';
 
 const defaults = {
     style: {},
     node: {chilren: []},
-    animations: factory.createAnimations(),
-    decorators: factory.createDecorators()
+    animations: createAnimations(),
+    decorators: createDecorators()
 };
 
 describe('node component', () => {
@@ -174,7 +174,7 @@ describe('node component', () => {
     });
 
     it('should pass velocity the drawer enter animation and duration props', () => {
-        const animations = factory.createAnimations();
+        const animations = createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       animations={animations}
@@ -187,7 +187,7 @@ describe('node component', () => {
     });
 
     it('should pass velocity the drawer leave animation and duration props', () => {
-        const animations = factory.createAnimations();
+        const animations = createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       animations={animations}
@@ -224,7 +224,7 @@ describe('node component', () => {
     });
 
     it('should render a velocity component if animations is an object', () => {
-        const animations = factory.createAnimations();
+        const animations = createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       animations={animations}
@@ -267,7 +267,7 @@ describe('node component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({loading: LoadingDecorator});
+        const decorators = createDecorators({loading: LoadingDecorator});
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       node={node}
@@ -285,7 +285,7 @@ describe('node component', () => {
                 return <div/>;
             }
         }
-        const decorators = factory.createDecorators({loading: LoadingDecorator});
+        const decorators = createDecorators({loading: LoadingDecorator});
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
                       node={node}

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -94,7 +94,11 @@ describe('node component', () => {
     });
 
     it('should use the node decorators if defined', () => {
-        const ContainerDecorator = React.createClass({render: () => <div/>});
+        class ContainerDecorator extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const nodeDecorators = {
             Container: ContainerDecorator
         };
@@ -109,7 +113,11 @@ describe('node component', () => {
     });
 
     it('should fallback to the prop decorators if the node decorators are not defined', () => {
-        const ContainerDecorator = React.createClass({render: () => <div/>});
+        class ContainerDecorator extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = {
             Container: ContainerDecorator
         };
@@ -254,7 +262,11 @@ describe('node component', () => {
 
     it('should render the loading decorator if the node is loading and toggled', () => {
         const node = {toggled: true, loading: true};
-        const LoadingDecorator = React.createClass({render: () => <div/>});
+        class LoadingDecorator extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({loading: LoadingDecorator});
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
@@ -268,7 +280,11 @@ describe('node component', () => {
 
     it('should not render the loading decorator if the node is not loading but toggled', () => {
         const node = {toggled: true, loading: false};
-        const LoadingDecorator = React.createClass({render: () => <div/>});
+        class LoadingDecorator extends React.Component {
+            render() {
+                return <div/>;
+            }
+        }
         const decorators = factory.createDecorators({loading: LoadingDecorator});
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -11,7 +11,7 @@ const factory = require('../utils/factory');
 
 const defaults = {
     style: {},
-    node: { chilren: [] },
+    node: {chilren: []},
     animations: factory.createAnimations(),
     decorators: factory.createDecorators()
 };
@@ -25,8 +25,8 @@ describe('node component', () => {
     });
 
     it('should invert the toggle state on click', (done) => {
-        const node = { toggled: true };
-        const onToggle = function(toggledNode, toggled){
+        const node = {toggled: true};
+        const onToggle = (toggledNode, toggled) => {
             toggled.should.equal(!toggledNode.toggled);
             done();
         };
@@ -56,15 +56,16 @@ describe('node component', () => {
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}/>
         );
-        (() => { treeNode.onClick(); }).should.not.throw(Error);
+
+        (() => treeNode.onClick()).should.not.throw(Error);
     });
 
     it('should use the node animations if defined', () => {
         const nodeAnimations = {
-            toggle: sinon.stub().returns({ duration: 0, animation: 'fadeIn' }),
-            drawer: sinon.stub().returns({ duration: 0, animation: 'fadeIn' })
+            toggle: sinon.stub().returns({duration: 0, animation: 'fadeIn'}),
+            drawer: sinon.stub().returns({duration: 0, animation: 'fadeIn'})
         };
-        const node = { animations: nodeAnimations };
+        const node = {animations: nodeAnimations};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode
                 {...defaults}
@@ -78,8 +79,8 @@ describe('node component', () => {
 
     it('should fallback to the prop animations if the node animations are not defined', () => {
         const animations = {
-            toggle: sinon.stub().returns({ duration: 0, animation: 'fadeIn' }),
-            drawer: sinon.stub().returns({ duration: 0, animation: 'fadeIn' })
+            toggle: sinon.stub().returns({duration: 0, animation: 'fadeIn'}),
+            drawer: sinon.stub().returns({duration: 0, animation: 'fadeIn'})
         };
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode
@@ -93,11 +94,11 @@ describe('node component', () => {
     });
 
     it('should use the node decorators if defined', () => {
-        const ContainerDecorator = React.createClass({ render: () => <div/> });
+        const ContainerDecorator = React.createClass({render: () => <div/>});
         const nodeDecorators = {
             Container: ContainerDecorator
         };
-        const node = { decorators: nodeDecorators, children: [] };
+        const node = {decorators: nodeDecorators, children: []};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode
                 {...defaults}
@@ -108,11 +109,11 @@ describe('node component', () => {
     });
 
     it('should fallback to the prop decorators if the node decorators are not defined', () => {
-        const ContainerDecorator = React.createClass({ render: () => <div/> });
+        const ContainerDecorator = React.createClass({render: () => <div/>});
         const decorators = {
             Container: ContainerDecorator
         };
-        const node = { children: [] };
+        const node = {children: []};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode
                 {...defaults}
@@ -127,7 +128,7 @@ describe('node component', () => {
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}/>
         );
-        const topLevel = treeNode.refs.topLevel;
+        const topLevel = treeNode.topLevelRef;
         topLevel.tagName.toLowerCase().should.equal('li');
     });
 
@@ -140,19 +141,19 @@ describe('node component', () => {
     });
 
     it('should render the subtree if toggled', () => {
-        const node = { toggled: true };
+        const node = {toggled: true};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults} node={node}/>
         );
-        treeNode.refs.subtree.should.exist;
+        treeNode.subtreeRef.should.exist;
     });
 
     it('should not render the children if not toggled', () => {
-        const node = { toggled: false };
+        const node = {toggled: false};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults} node={node}/>
         );
-        global.should.not.exist(treeNode.refs.subtree);
+        global.should.not.exist(treeNode.subtreeRef);
     });
 
     it('should wrap the children in a velocity transition group', () => {
@@ -168,10 +169,10 @@ describe('node component', () => {
         const animations = factory.createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                animations={animations}
+                      animations={animations}
             />
         );
-        const velocity = treeNode.refs.velocity;
+        const velocity = treeNode.velocityRef;
         const drawer = animations.drawer();
         velocity.props.enter.animation.should.equal(drawer.enter.animation);
         velocity.props.enter.duration.should.equal(drawer.enter.duration);
@@ -181,36 +182,36 @@ describe('node component', () => {
         const animations = factory.createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                animations={animations}
+                      animations={animations}
             />
         );
-        const velocity = treeNode.refs.velocity;
+        const velocity = treeNode.velocityRef;
         const drawer = animations.drawer();
         velocity.props.leave.animation.should.equal(drawer.leave.animation);
         velocity.props.leave.duration.should.equal(drawer.leave.duration);
     });
 
     it('should not render a velocity component if animations is false and not toggled', () => {
-        const node = { toggled: false };
+        const node = {toggled: false};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                animations={false}
-                node={node}
+                      animations={false}
+                      node={node}
             />
         );
-        const velocity = treeNode.refs.velocity;
+        const velocity = treeNode.velocityRef;
         global.should.not.exist(velocity);
     });
 
     it('should not render a velocity component if animations is false and toggled', () => {
-        const node = { toggled: true };
+        const node = {toggled: true};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                animations={false}
-                node={node}
+                      animations={false}
+                      node={node}
             />
         );
-        const velocity = treeNode.refs.velocity;
+        const velocity = treeNode.velocityRef;
         global.should.not.exist(velocity);
     });
 
@@ -218,32 +219,32 @@ describe('node component', () => {
         const animations = factory.createAnimations();
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                animations={animations}
+                      animations={animations}
             />
         );
-        const velocity = treeNode.refs.velocity;
+        const velocity = treeNode.velocityRef;
         velocity.should.exist;
     });
 
     it('should wrap the children in a list', () => {
-        const node = { toggled: true };
+        const node = {toggled: true};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
+                      node={node}
             />
         );
-        const subtree = treeNode.refs.subtree;
+        const subtree = treeNode.subtreeRef;
         subtree.tagName.toLowerCase().should.equal('ul');
     });
 
     it('should render a TreeNode component for each child', () => {
         const node = {
             toggled: true,
-            children: [ {node: {}}, {node: {}}, {node: {}} ]
+            children: [{node: {}}, {node: {}}, {node: {}}]
         };
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
+                      node={node}
             />
         );
         // Find All TreeNodes (+ Top Level TreeNode)
@@ -252,13 +253,13 @@ describe('node component', () => {
     });
 
     it('should render the loading decorator if the node is loading and toggled', () => {
-        const node = { toggled: true, loading: true };
-        const LoadingDecorator = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ loading: LoadingDecorator });
+        const node = {toggled: true, loading: true};
+        const LoadingDecorator = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({loading: LoadingDecorator});
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
-                decorators={decorators}
+                      node={node}
+                      decorators={decorators}
             />
         );
         const loading = TestUtils.findRenderedComponentWithType(treeNode, LoadingDecorator);
@@ -266,13 +267,13 @@ describe('node component', () => {
     });
 
     it('should not render the loading decorator if the node is not loading but toggled', () => {
-        const node = { toggled: true, loading: false };
-        const LoadingDecorator = React.createClass({ render: () => <div/> });
-        const decorators = factory.createDecorators({ loading: LoadingDecorator });
+        const node = {toggled: true, loading: false};
+        const LoadingDecorator = React.createClass({render: () => <div/>});
+        const decorators = factory.createDecorators({loading: LoadingDecorator});
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
-                decorators={decorators}
+                      node={node}
+                      decorators={decorators}
             />
         );
         const loading = TestUtils.scryRenderedComponentsWithType(treeNode, LoadingDecorator);
@@ -280,24 +281,24 @@ describe('node component', () => {
     });
 
     it('should not render the children if the node is Loading', () => {
-        const node = { toggled: true, loading: true };
+        const node = {toggled: true, loading: true};
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
+                      node={node}
             />
         );
-        global.should.not.exist(treeNode.refs.subtree);
+        global.should.not.exist(treeNode.subtreeRef);
     });
 
     it('should render a child with an id key if available', () => {
         const id = 'SpecialNode';
         const node = {
             toggled: true,
-            children: [{ id }]
+            children: [{id}]
         };
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
+                      node={node}
             />
         );
         const nodes = TestUtils.scryRenderedComponentsWithType(treeNode, TreeNode);
@@ -309,11 +310,11 @@ describe('node component', () => {
     it('should render a child with an index key if id is not available', () => {
         const node = {
             toggled: true,
-            children: [{ name: 'node' }]
+            children: [{name: 'node'}]
         };
         const treeNode = TestUtils.renderIntoDocument(
             <TreeNode {...defaults}
-                node={node}
+                      node={node}
             />
         );
         const nodes = TestUtils.scryRenderedComponentsWithType(treeNode, TreeNode);

--- a/test/src/components/node-tests.js
+++ b/test/src/components/node-tests.js
@@ -305,37 +305,4 @@ describe('node component', () => {
         );
         global.should.not.exist(treeNode.subtreeRef);
     });
-
-    it('should render a child with an id key if available', () => {
-        const id = 'SpecialNode';
-        const node = {
-            toggled: true,
-            children: [{id}]
-        };
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults}
-                      node={node}
-            />
-        );
-        const nodes = TestUtils.scryRenderedComponentsWithType(treeNode, TreeNode);
-        const element = ReactDOM.findDOMNode(nodes[1]);
-        const expectedId = '$' + id;
-        element.dataset.reactid.should.contain(expectedId);
-    });
-
-    it('should render a child with an index key if id is not available', () => {
-        const node = {
-            toggled: true,
-            children: [{name: 'node'}]
-        };
-        const treeNode = TestUtils.renderIntoDocument(
-            <TreeNode {...defaults}
-                      node={node}
-            />
-        );
-        const nodes = TestUtils.scryRenderedComponentsWithType(treeNode, TreeNode);
-        const element = ReactDOM.findDOMNode(nodes[1]);
-        const expectedId = '$0';
-        element.dataset.reactid.should.contain(expectedId);
-    });
 });

--- a/test/src/components/treebeard-tests.js
+++ b/test/src/components/treebeard-tests.js
@@ -18,7 +18,7 @@ describe('treebeard component', () => {
         const treebeard = TestUtils.renderIntoDocument(
             <Treebeard data={defaults}/>
         );
-        const treeBase = treebeard.refs.treeBase;
+        const treeBase = treebeard.treeBaseRef;
         treeBase.tagName.toLowerCase().should.equal('ul');
     });
 
@@ -32,10 +32,8 @@ describe('treebeard component', () => {
 
     it('should pass the top level tree node the associated props', () => {
         const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard
-                data={defaults}
-                onToggle={()=>{}}
-            />
+            <Treebeard data={defaults}
+                       onToggle={() => null}/>
         );
         const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
         node.props.node.should.equal(treebeard.props.data);
@@ -71,8 +69,8 @@ describe('treebeard component', () => {
 
     it('should support rendering multiple nodes at the root level', () => {
         const multipleRootNodes = [
-            { name: 'root-1', children: [] },
-            { name: 'root-2', children: [] }
+            {name: 'root-1', children: []},
+            {name: 'root-2', children: []}
         ];
         const treebeard = TestUtils.renderIntoDocument(
             <Treebeard data={multipleRootNodes}/>
@@ -83,7 +81,7 @@ describe('treebeard component', () => {
 
     it('should render a root node with an id key if available', () => {
         const id = 'RootNode';
-        const rootNode = { id: id, name: 'root-1', children: [] };
+        const rootNode = {id: id, name: 'root-1', children: []};
         const treebeard = TestUtils.renderIntoDocument(
             <Treebeard data={rootNode}/>
         );
@@ -94,7 +92,7 @@ describe('treebeard component', () => {
     });
 
     it('should render a root node with an index key if id is not available', () => {
-        const rootNode = { name: 'root-1', children: [] };
+        const rootNode = {name: 'root-1', children: []};
         const treebeard = TestUtils.renderIntoDocument(
             <Treebeard data={rootNode}/>
         );

--- a/test/src/components/treebeard-tests.js
+++ b/test/src/components/treebeard-tests.js
@@ -3,10 +3,13 @@
 'use strict';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import TestUtils from 'react-dom/test-utils';
+
+import defaultDecorators from '../../../src/components/decorators';
 import TreeNode from '../../../src/components/node';
 import Treebeard from '../../../src/components/treebeard';
+import defaultAnimations from '../../../src/themes/animations';
+import defaultTheme from '../../../src/themes/default';
 
 const defaults = {
     name: '',
@@ -15,18 +18,16 @@ const defaults = {
 
 describe('treebeard component', () => {
     it('should render the treebase as a list', () => {
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={defaults}/>
-        );
+        const treebeard = TestUtils.renderIntoDocument(<Treebeard data={defaults}/>);
         const treeBase = treebeard.treeBaseRef;
+
         treeBase.tagName.toLowerCase().should.equal('ul');
     });
 
     it('should render the treebase as a list', () => {
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={defaults}/>
-        );
+        const treebeard = TestUtils.renderIntoDocument(<Treebeard data={defaults}/>);
         const nodes = TestUtils.scryRenderedComponentsWithType(treebeard, TreeNode);
+
         nodes.length.should.equal(1);
     });
 
@@ -36,34 +37,29 @@ describe('treebeard component', () => {
                        onToggle={() => null}/>
         );
         const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
+
         node.props.node.should.equal(treebeard.props.data);
         node.props.onToggle.should.equal(treebeard.props.onToggle);
     });
 
     it('should use the default theme if none specified', () => {
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={defaults}/>
-        );
+        const treebeard = TestUtils.renderIntoDocument(<Treebeard data={defaults}/>);
         const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
-        const defaultTheme = require('../../../src/themes/default');
+
         node.props.style.should.equal(defaultTheme.tree.node);
     });
 
     it('should use the default animations if none specified', () => {
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={defaults}/>
-        );
+        const treebeard = TestUtils.renderIntoDocument(<Treebeard data={defaults}/>);
         const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
-        const defaultAnimations = require('../../../src/themes/animations');
+
         node.props.animations.should.equal(defaultAnimations);
     });
 
     it('should use the default decorators if none specified', () => {
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={defaults}/>
-        );
+        const treebeard = TestUtils.renderIntoDocument(<Treebeard data={defaults}/>);
         const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
-        const defaultDecorators = require('../../../src/components/decorators');
+
         node.props.decorators.should.equal(defaultDecorators);
     });
 
@@ -72,10 +68,9 @@ describe('treebeard component', () => {
             {name: 'root-1', children: []},
             {name: 'root-2', children: []}
         ];
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={multipleRootNodes}/>
-        );
+        const treebeard = TestUtils.renderIntoDocument(<Treebeard data={multipleRootNodes}/>);
         const nodes = TestUtils.scryRenderedComponentsWithType(treebeard, TreeNode);
+
         nodes.length.should.equal(multipleRootNodes.length);
     });
 });

--- a/test/src/components/treebeard-tests.js
+++ b/test/src/components/treebeard-tests.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const TestUtils = require('react-dom/test-utils');
-const TreeNode = require('../../../src/components/node');
-const Treebeard = require('../../../src/components/treebeard');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-dom/test-utils';
+import TreeNode from '../../../src/components/node';
+import Treebeard from '../../../src/components/treebeard';
 
 const defaults = {
     name: '',

--- a/test/src/components/treebeard-tests.js
+++ b/test/src/components/treebeard-tests.js
@@ -78,28 +78,4 @@ describe('treebeard component', () => {
         const nodes = TestUtils.scryRenderedComponentsWithType(treebeard, TreeNode);
         nodes.length.should.equal(multipleRootNodes.length);
     });
-
-    it('should render a root node with an id key if available', () => {
-        const id = 'RootNode';
-        const rootNode = {id: id, name: 'root-1', children: []};
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={rootNode}/>
-        );
-        const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
-        const element = ReactDOM.findDOMNode(node);
-        const expectedId = '$' + id;
-        element.dataset.reactid.should.contain(expectedId);
-    });
-
-    it('should render a root node with an index key if id is not available', () => {
-        const rootNode = {name: 'root-1', children: []};
-        const treebeard = TestUtils.renderIntoDocument(
-            <Treebeard data={rootNode}/>
-        );
-        const node = TestUtils.findRenderedComponentWithType(treebeard, TreeNode);
-        const element = ReactDOM.findDOMNode(node);
-        const expectedId = '$0';
-        element.dataset.reactid.should.contain(expectedId);
-    });
-
 });

--- a/test/src/components/treebeard-tests.js
+++ b/test/src/components/treebeard-tests.js
@@ -4,7 +4,7 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const TestUtils = require('react-addons-test-utils');
+const TestUtils = require('react-dom/test-utils');
 const TreeNode = require('../../../src/components/node');
 const Treebeard = require('../../../src/components/treebeard');
 

--- a/test/src/utils/factory.js
+++ b/test/src/utils/factory.js
@@ -1,46 +1,45 @@
 'use strict';
 
-const React = require('react');
+import React from 'react';
 
-module.exports = {
-    createDecorators: function(spec){
-        spec = spec || {};
-        return {
-            Loading: (props) => {
-                return spec.loading ? <spec.loading {...props}/> : <div/>;
-            },
-            Toggle: (props) => {
-                return spec.toggle ? <spec.toggle {...props}/> : <div/>;
-            },
-            Header: (props) => {
-                return spec.header ? <spec.header {...props}/> : <div/>;
-            },
-            Container: (props) => {
-                return spec.container ? <spec.container {...props}/> : <div/>;
-            }
+export const createDecorators = (spec) => {
+    spec = spec || {};
+    return {
+        Loading: (props) => {
+            return spec.loading ? <spec.loading {...props}/> : <div/>;
+        },
+        Toggle: (props) => {
+            return spec.toggle ? <spec.toggle {...props}/> : <div/>;
+        },
+        Header: (props) => {
+            return spec.header ? <spec.header {...props}/> : <div/>;
+        },
+        Container: (props) => {
+            return spec.container ? <spec.container {...props}/> : <div/>;
+        }
 
-        };
-    },
-    createAnimations: function(){
-        return {
-            toggle: () => {
-                return {
-                    animation: 'fadeOut',
+    };
+};
+
+export const createAnimations = () => {
+    return {
+        toggle: () => {
+            return {
+                animation: 'fadeOut',
+                duration: 0
+            };
+        },
+        drawer: () => {
+            return {
+                enter: {
+                    animation: 'slideDown',
                     duration: 0
-                };
-            },
-            drawer: () => {
-                return {
-                    enter: {
-                        animation: 'slideDown',
-                        duration: 0
-                    },
-                    leave: {
-                        animation: 'slideUp',
-                        duration: 0
-                    }
-                };
-            }
-        };
-    }
+                },
+                leave: {
+                    animation: 'slideUp',
+                    duration: 0
+                }
+            };
+        }
+    };
 };


### PR DESCRIPTION
- [x] Fixes dependencies for `velocity-react` & `radium`
- [x] Uses `prop-types` package instead of `React.PropTypes` (closes #63)
- [x] Uses ES6 classes instead of `React.createClass` in tests (closes #64)
- [x] Uses `react-dom/test-utils` package instead of `react-addons-test-utils` in tests (closes #65)
- [x] Some code clean-up
- [x] Deletes deprecated tests (`reactid` isn't used anymore since `React v15.0`)