### PR TITLE
migrate to babel6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,20 @@
 {
-  "stage": 0,
-  "optional": ["runtime"]
+  "presets": [
+    "stage-0",
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "last 4 versions"
+          ]
+        }
+      }
+    ]
+  ],
+  "plugins": [
+    "transform-runtime",
+    "transform-react-jsx",
+    "transform-decorators-legacy"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,15 @@
   },
   "homepage": "https://github.com/alexcurtis/react-treebeard#readme",
   "devDependencies": {
-    "babel": "^5.8.29",
-    "babel-core": "^5.8.29",
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
     "babel-eslint": "^4.1.3",
-    "babel-loader": "^5.3.3",
+    "babel-loader": "^6.0.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-stage-0": "^6.24.1",
     "chai": "^3.4.0",
     "del": "^2.0.2",
     "eslint": "^1.8.0",
@@ -70,7 +75,7 @@
     "webpack-dev-server": "^1.12.1"
   },
   "dependencies": {
-    "babel-runtime": "^5.8.29",
+    "babel-runtime": "^6.23.0",
     "deep-equal": "^1.0.1",
     "prop-types": "^15.5.8",
     "radium": "^0.19.0",

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -6,7 +6,7 @@ module.exports = {
         loaders: [{
             test: /\.js$/,
             exclude: [/node_modules/],
-            loaders: ['babel-loader?stage=0']
+            loaders: ['babel-loader']
         }],
         postLoaders: [{
             test: /\.js$/,


### PR DESCRIPTION
In our projects, only this package depends on babel-runtime v5.x.

Please upgrade babel runtime to v6!